### PR TITLE
Add OpenAI compatibility API

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,17 @@ pnpm dev
 
 The web interface will be available at `http://localhost:3000`
 
+### OpenAI-Compatible API
+
+The backend exposes `/v1/chat/completions` and `/v1/completions` endpoints that
+follow the OpenAI API schema. Set the following environment variables as needed:
+
+```bash
+export OLLAMA_API_BASE=<ollama-host:port>
+export AZURE_OPENAI_API_VERSION=<azure-version>
+```
+
+Send OpenAI-style requests to `http://localhost:8000/v1/chat/completions` or
+`http://localhost:8000/v1/completions` and the request will be routed to the
+appropriate Agno team (`HackerNewsTeam` or `ResearchTeam`).
+

--- a/api/openai_router.py
+++ b/api/openai_router.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import time
+from typing import Iterator, List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from teams import HackerNewsTeam, ResearchTeam
+
+router = APIRouter()
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+class ChatCompletionRequest(BaseModel):
+    model: str = Field(..., description="Model or team identifier")
+    messages: List[ChatMessage]
+    stream: Optional[bool] = False
+
+class CompletionRequest(BaseModel):
+    model: str = Field(..., description="Model or team identifier")
+    prompt: str
+    stream: Optional[bool] = False
+
+
+def _select_team(model: str):
+    if "hackernews" in model.lower() or "hn" in model.lower():
+        return HackerNewsTeam
+    return ResearchTeam
+
+
+def _run_team(team, prompt: str, stream: bool):
+    try:
+        resp = team.run(prompt, stream=stream)
+    except Exception as e:  # pragma: no cover - runtime errors
+        raise HTTPException(status_code=500, detail=str(e))
+
+    if stream:
+        # Concatenate streamed content pieces
+        content = "".join(
+            r.content for r in resp if getattr(r, "content", None)
+        )
+    else:
+        content = resp.content if hasattr(resp, "content") else str(resp)
+    return content
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(req: ChatCompletionRequest):
+    team = _select_team(req.model)
+    prompt = "\n".join(m.content for m in req.messages if m.role == "user")
+    content = _run_team(team, prompt, req.stream or False)
+    return {
+        "id": f"chatcmpl-{int(time.time()*1000)}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": req.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+@router.post("/v1/completions")
+async def completions(req: CompletionRequest):
+    team = _select_team(req.model)
+    content = _run_team(team, req.prompt, req.stream or False)
+    return {
+        "id": f"cmpl-{int(time.time()*1000)}",
+        "object": "text_completion",
+        "created": int(time.time()),
+        "model": req.model,
+        "choices": [
+            {
+                "index": 0,
+                "text": content,
+                "finish_reason": "stop",
+            }
+        ],
+    }

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from agno import playground
 from teams import HackerNewsTeam, ResearchTeam
+from api.openai_router import router as openai_router
 
 app = playground.Playground(
     teams=[
@@ -7,6 +8,8 @@ app = playground.Playground(
         ResearchTeam,
     ],
 ).get_app(use_async=False)
+
+app.include_router(openai_router)
 
 if __name__ == "__main__":
     playground.serve_playground_app("main:app", reload=True)


### PR DESCRIPTION
## Summary
- add router implementing /v1/chat/completions and /v1/completions
- mount router in FastAPI application
- document OpenAI style endpoints and env vars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410c5d19048325844e0b2077739e9a